### PR TITLE
Enable use in multiple contexts

### DIFF
--- a/src/node_libcurl.cc
+++ b/src/node_libcurl.cc
@@ -63,5 +63,5 @@ NAN_MODULE_INIT(Init) {
 #endif
 }
 
-NODE_MODULE(node_libcurl, Init);
+NAN_MODULE_WORKER_ENABLED(node_libcurl, Init);
 }  // namespace NodeLibcurl


### PR DESCRIPTION
Seems to work fine in Workers after this change. Fixes #65.